### PR TITLE
Add timeout option to the rx subcommand

### DIFF
--- a/src/util/operations.rs
+++ b/src/util/operations.rs
@@ -172,11 +172,13 @@ where
 	let elapsed_time = start_time.elapsed().unwrap();
 
 	// If timeout value given then check for timeout
-       	if options.timeout.as_secs() != 0 && options.timeout.as_secs() < elapsed_time.as_secs() {
-		info!("Receiver Timed Out");
-		return Ok(0);			// No Message Received
+       	match options.timeout {
+   		Some(d) if elapsed_time > *d => {
+			info!("Receiver Timed Out");
+			return Ok(0);			// No Message Received
+    		},
+	_ => (),
 	}
-
 
 
         HalDelay{}.try_delay_us(options.poll_interval.as_micros() as u32).unwrap();

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -290,7 +290,7 @@ pub struct Receive {
     pub append_fcs: bool,
 
     /// Add a timeout after which to stop receiving
-    #[structopt(long = "timeout", default_value="0s")]
+    #[structopt(long)]
     pub timeout: Option<HumanDuration>,
 }
 

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -291,7 +291,7 @@ pub struct Receive {
 
     /// Add a timeout after which to stop receiving
     #[structopt(long = "timeout", default_value="0s")]
-    pub timeout: HumanDuration,
+    pub timeout: Option<HumanDuration>,
 }
 
 #[derive(Clone, StructOpt, PartialEq, Debug)]

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -288,6 +288,10 @@ pub struct Receive {
     /// Append FCS to received data
     #[structopt(long)]
     pub append_fcs: bool,
+
+    /// Add a timeout after which to stop receiving
+    #[structopt(long = "timeout", default_value="0s")]
+    pub timeout: HumanDuration,
 }
 
 #[derive(Clone, StructOpt, PartialEq, Debug)]


### PR DESCRIPTION
Added a timeout option for the receive command. Default set to 0. If zero, there's no timeout and code runs as initially. Usage can be seen using the help (--help, -h) flag.

Edited the options.rs to include the timeout in options.
Implemented the functionality in operations.rs 