### PR TITLE
Simplifying trait bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,14 @@ bin-dir = "{ bin }-{ target }{ format }"
 
 
 [features]
+
+defmt-default = []
+defmt-trace = []
+defmt-debug = []
+defmt-info = []
+defmt-warn = []
+defmt-error = []
+
 std = [ "radio/std", "driver-pal/mock", "failure/std", "hex", "thiserror" ]
 poll-irq = []
 patch-unknown-state = []
@@ -32,6 +40,7 @@ driver-pal = { version = "0.8.0-alpha.6", default_features = false, optional=tru
 bitflags = "1.0.4"
 libc = "0.2.95"
 log = { version = "0.4.14", default_features = false }
+strum = { version = "0.24.0", default_features = false, features = [ "derive" ] }
 
 crc16 = { version = "0.4.0", optional = true }
 hex = { version = "0.4.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ std = [ "radio/std", "driver-pal/mock", "failure/std", "hex", "thiserror" ]
 poll-irq = []
 patch-unknown-state = []
 tests = [ "driver-pal/mock" ]
-util = ["structopt", "tracing", "tracing-subscriber", "humantime", "crc16", "driver-pal", "driver-pal/hal", "radio/helpers"]
+util = [ "std", "structopt", "tracing", "tracing-subscriber", "humantime", "crc16", "driver-pal", "driver-pal/hal", "radio/helpers" ]
 
 default = [ "std", "util", "serde", "driver-pal/hal-cp2130", "driver-pal/hal-linux", "patch-unknown-state" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ std = [ "radio/std", "driver-pal/mock", "failure/std", "hex", "thiserror" ]
 poll-irq = []
 patch-unknown-state = []
 tests = [ "driver-pal/mock" ]
-util = ["structopt", "tracing", "tracing-subscriber", "humantime", "crc16", "driver-pal/hal", "radio/helpers"]
+util = ["structopt", "tracing", "tracing-subscriber", "humantime", "crc16", "driver-pal", "driver-pal/hal", "radio/helpers"]
 
 default = [ "std", "util", "serde", "driver-pal/hal-cp2130", "driver-pal/hal-linux", "patch-unknown-state" ]
 
@@ -26,7 +26,7 @@ default = [ "std", "util", "serde", "driver-pal/hal-cp2130", "driver-pal/hal-lin
 radio = { version = "0.11.0", default_features = false }
 embedded-hal = "1.0.0-alpha.7"
 
-driver-pal = { version = "0.8.0-alpha.6", default_features = false }
+driver-pal = { version = "0.8.0-alpha.6", default_features = false, optional=true }
 
 bitflags = "1.0.4"
 libc = "0.2.95"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ default = [ "std", "util", "serde", "driver-pal/hal-cp2130", "driver-pal/hal-lin
 [dependencies]
 radio = { version = "0.11.0", default_features = false }
 embedded-hal = "1.0.0-alpha.7"
+defmt = {version = "0.3.0", optional = true }
 
 driver-pal = { version = "0.8.0-alpha.6", default_features = false, optional=true }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -4,73 +4,79 @@ use core::fmt::Debug;
 
 use log::{error, trace};
 
+use embedded_hal::digital::PinState;
+use embedded_hal::digital::blocking::{InputPin, OutputPin};
+
+
 use embedded_hal::delay::blocking::DelayUs;
-use embedded_hal::spi::blocking::Transactional;
+use embedded_hal::spi::blocking::{Transactional, Operation};
 
-use driver_pal::Error as SpiError;
-use driver_pal::{Busy, PinState, PrefixRead, PrefixWrite, Ready, Reset};
-
-use crate::device::*;
+use crate::{device::*, SpiBase};
 use crate::Error;
 
 /// Hal implementation can be generic over SPI or UART connections
-pub trait Hal<CommsError: Debug, PinError: Debug, DelayError: Debug> {
+pub trait Hal {
+    type CommsError: Debug + 'static;
+    type PinError: Debug + 'static;
+    type DelayError: Debug + 'static;
+
     /// Reset the device
-    fn reset(&mut self) -> Result<(), Error<CommsError, PinError, DelayError>>;
+    fn reset(&mut self) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>>;
 
     /// Fetch radio device busy pin value
-    fn get_busy(&mut self) -> Result<PinState, Error<CommsError, PinError, DelayError>>;
+    fn get_busy(&mut self) -> Result<PinState, Error<Self::CommsError, Self::PinError, Self::DelayError>>;
 
     /// Fetch radio device ready / irq (DIO) pin value
-    fn get_dio(&mut self) -> Result<PinState, Error<CommsError, PinError, DelayError>>;
+    fn get_dio(&mut self) -> Result<PinState, Error<Self::CommsError, Self::PinError, Self::DelayError>>;
 
     /// Delay for the specified time
-    fn delay_ms(&mut self, ms: u32) -> Result<(), DelayError>;
+    fn delay_ms(&mut self, ms: u32) -> Result<(), Self::DelayError>;
 
     /// Delay for the specified time
-    fn delay_us(&mut self, us: u32) -> Result<(), DelayError>;
+    fn delay_us(&mut self, us: u32) -> Result<(), Self::DelayError>;
 
     /// Write the specified command and data
     fn write_cmd(
         &mut self,
         command: u8,
         data: &[u8],
-    ) -> Result<(), Error<CommsError, PinError, DelayError>>;
+    ) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>>;
     /// Read the specified command and data
     fn read_cmd(
         &mut self,
         command: u8,
         data: &mut [u8],
-    ) -> Result<(), Error<CommsError, PinError, DelayError>>;
+    ) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>>;
 
     /// Write to the specified register
     fn write_regs(
         &mut self,
         reg: u16,
         data: &[u8],
-    ) -> Result<(), Error<CommsError, PinError, DelayError>>;
+    ) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>>;
     /// Read from the specified register
     fn read_regs(
         &mut self,
         reg: u16,
         data: &mut [u8],
-    ) -> Result<(), Error<CommsError, PinError, DelayError>>;
+    ) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>>;
 
     /// Write to the specified buffer
     fn write_buff(
         &mut self,
         offset: u8,
         data: &[u8],
-    ) -> Result<(), Error<CommsError, PinError, DelayError>>;
+    ) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>>;
+
     /// Read from the specified buffer
     fn read_buff(
         &mut self,
         offset: u8,
         data: &mut [u8],
-    ) -> Result<(), Error<CommsError, PinError, DelayError>>;
+    ) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>>;
 
     /// Wait on radio device busy
-    fn wait_busy(&mut self) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    fn wait_busy(&mut self) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>> {
         // TODO: timeouts here
         let mut timeout = 0;
         while self.get_busy()? == PinState::High {
@@ -87,7 +93,7 @@ pub trait Hal<CommsError: Debug, PinError: Debug, DelayError: Debug> {
     }
 
     /// Read a single u8 value from the specified register
-    fn read_reg(&mut self, reg: u16) -> Result<u8, Error<CommsError, PinError, DelayError>> {
+    fn read_reg(&mut self, reg: u16) -> Result<u8, Error<Self::CommsError, Self::PinError, Self::DelayError>> {
         let mut incoming = [0u8; 1];
         self.read_regs(reg.into(), &mut incoming)?;
         Ok(incoming[0])
@@ -98,7 +104,7 @@ pub trait Hal<CommsError: Debug, PinError: Debug, DelayError: Debug> {
         &mut self,
         reg: u16,
         value: u8,
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>> {
         self.write_regs(reg.into(), &[value])?;
         Ok(())
     }
@@ -109,56 +115,123 @@ pub trait Hal<CommsError: Debug, PinError: Debug, DelayError: Debug> {
         reg: u16,
         mask: u8,
         value: u8,
-    ) -> Result<u8, Error<CommsError, PinError, DelayError>> {
+    ) -> Result<u8, Error<Self::CommsError, Self::PinError, Self::DelayError>> {
         let existing = self.read_reg(reg)?;
         let updated = (existing & !mask) | (value & mask);
         self.write_reg(reg, updated)?;
         Ok(updated)
     }
+
+    fn prefix_read(&mut self, prefix: &[u8], data: &mut [u8]) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>>;
+
+    fn prefix_write(&mut self, prefix: &[u8], data: &[u8]) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>>;
 }
 
-impl<T, CommsError, PinError, DelayError> Hal<CommsError, PinError, DelayError> for T
+pub trait HalError {
+    type E: Debug;
+}
+
+impl <T> HalError for T
 where
-    T: Transactional<u8, Error = SpiError<CommsError, PinError, DelayError>>
-        + PrefixRead<Error = SpiError<CommsError, PinError, DelayError>>
-        + PrefixWrite<Error = SpiError<CommsError, PinError, DelayError>>,
-    T: Reset<Error = PinError>,
-    T: Busy<Error = PinError>,
-    T: Ready<Error = PinError>,
-    T: DelayUs<Error = DelayError>,
-    CommsError: Debug,
-    PinError: Debug,
-    DelayError: Debug,
+    T: Hal,
 {
+    type E = Error<<T as Hal>::CommsError, <T as Hal>::PinError, <T as Hal>::DelayError>;
+}
+
+/// Base interface for radio device
+pub struct Base <Spi: SpiBase, Cs: OutputPin, Busy: InputPin, Ready: InputPin, Sdn: OutputPin, Delay: DelayUs> {
+    pub spi: Spi,
+    pub cs: Cs,
+    pub busy: Busy,
+    pub ready: Ready,
+    pub sdn: Sdn,
+    pub delay: Delay,
+}
+
+
+impl<Spi, Cs, Busy, Ready, Sdn, PinError, Delay> Hal for Base<Spi, Cs, Busy, Ready, Sdn, Delay>
+where
+    Spi: SpiBase,
+    <Spi as SpiBase>::Error: Debug + 'static,
+    
+    Cs: OutputPin<Error=PinError>,
+    Busy: InputPin<Error=PinError>,
+    Ready: InputPin<Error=PinError>,
+    Sdn: OutputPin<Error=PinError>,
+    PinError: Debug + 'static,
+
+    Delay: DelayUs,
+    <Delay as DelayUs>::Error: Debug + 'static,
+{
+    type CommsError = <Spi as SpiBase>::Error;
+    type PinError = PinError;
+    type DelayError = <Delay as DelayUs>::Error;
+
     /// Reset the radio
-    fn reset(&mut self) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    fn reset(&mut self) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>> {
         self.delay_ms(20).map_err(Error::Delay)?;
-        self.set_reset(PinState::Low).map_err(Error::Pin)?;
+        
+        self.sdn.set_low().map_err(Error::Pin)?;
+        
         self.delay_ms(50).map_err(Error::Delay)?;
-        self.set_reset(PinState::High).map_err(Error::Pin)?;
+        
+        self.sdn.set_high().map_err(Error::Pin)?;
+        
         self.delay_ms(20).map_err(Error::Delay)?;
 
         Ok(())
     }
 
-    fn get_busy(&mut self) -> Result<PinState, Error<CommsError, PinError, DelayError>> {
-        let busy = self.get_busy().map_err(Error::Pin)?;
-        Ok(busy)
+    fn get_busy(&mut self) -> Result<PinState, Error<Self::CommsError, Self::PinError, Self::DelayError>> {
+        match self.busy.is_high().map_err(Error::Pin)? {
+            true => Ok(PinState::High),
+            false => Ok(PinState::Low),
+        }
     }
 
-    fn get_dio(&mut self) -> Result<PinState, Error<CommsError, PinError, DelayError>> {
-        let dio = self.get_ready().map_err(Error::Pin)?;
-        Ok(dio)
+    fn get_dio(&mut self) -> Result<PinState, Error<Self::CommsError, Self::PinError, Self::DelayError>> {
+        match self.ready.is_high().map_err(Error::Pin)? {
+            true => Ok(PinState::High),
+            false => Ok(PinState::Low),
+        }
     }
 
     /// Delay for the specified time
-    fn delay_ms(&mut self, ms: u32) -> Result<(), DelayError> {
-        DelayUs::delay_ms(self, ms)
+    fn delay_ms(&mut self, ms: u32) -> Result<(), <Delay as DelayUs>::Error> {
+        self.delay.delay_ms(ms)
     }
 
     /// Delay for the specified time
-    fn delay_us(&mut self, ms: u32) -> Result<(), DelayError> {
-        DelayUs::delay_us(self, ms)
+    fn delay_us(&mut self, ms: u32) -> Result<(), <Delay as DelayUs>::Error> {
+        self.delay.delay_us(ms)
+    }
+
+    /// Write data with prefix, asserting CS as required
+    fn prefix_write(&mut self, prefix: &[u8], data: &[u8]) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>> {
+        self.cs.set_low().map_err(Error::Pin)?;
+
+        let r = self.spi.exec(&mut [
+            Operation::Write(prefix),
+            Operation::Write(data),
+        ]).map_err(Error::Comms);
+
+        self.cs.set_high().map_err(Error::Pin)?;
+
+        r
+    }
+
+    /// Read data with prefix, asserting CS as required
+    fn prefix_read(&mut self, prefix: &[u8], data: &mut [u8]) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>> {
+        self.cs.set_low().map_err(Error::Pin)?;
+
+        let r = self.spi.exec(&mut [
+            Operation::Write(prefix),
+            Operation::Read(data),
+        ]).map_err(Error::Comms);
+
+        self.cs.set_high().map_err(Error::Pin)?;
+
+        r
     }
 
     /// Write the specified command and data
@@ -166,14 +239,16 @@ where
         &mut self,
         command: u8,
         data: &[u8],
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>> {
         // Setup register write command
         let out_buf: [u8; 1] = [command as u8];
 
         trace!("write_cmd cmd: {:02x?} data: {:02x?}", out_buf, data);
 
         self.wait_busy()?;
-        let r = self.prefix_write(&out_buf, data).map_err(|e| e.into());
+
+        let r = self.prefix_write(&out_buf, data);
+        
         self.wait_busy()?;
         r
     }
@@ -183,15 +258,14 @@ where
         &mut self,
         command: u8,
         data: &mut [u8],
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>> {
         // Setup register read command
         let out_buf: [u8; 2] = [command as u8, 0x00];
 
         self.wait_busy()?;
-        let r = self
-            .prefix_read(&out_buf, data)
-            .map(|_| ())
-            .map_err(|e| e.into());
+        
+        let r = self.prefix_read(&out_buf, data);
+        
         self.wait_busy()?;
 
         trace!("read_cmd cmd: {:02x?} data: {:02x?}", out_buf, data);
@@ -204,7 +278,7 @@ where
         &mut self,
         reg: u16,
         data: &[u8],
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>> {
         // Setup register write command
         let out_buf: [u8; 3] = [
             Commands::WiteRegister as u8,
@@ -215,7 +289,9 @@ where
         trace!("write_regs cmd: {:02x?} data: {:02x?}", out_buf, data);
 
         self.wait_busy()?;
-        let r = self.prefix_write(&out_buf, data).map_err(|e| e.into());
+        
+        let r = self.prefix_write(&out_buf, data);
+
         self.wait_busy()?;
         r
     }
@@ -225,7 +301,7 @@ where
         &mut self,
         reg: u16,
         data: &mut [u8],
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>> {
         // Setup register read command
         let out_buf: [u8; 4] = [
             Commands::ReadRegister as u8,
@@ -235,10 +311,9 @@ where
         ];
 
         self.wait_busy()?;
-        let r = self
-            .prefix_read(&out_buf, data)
-            .map(|_| ())
-            .map_err(|e| e.into());
+        
+        let r = self.prefix_read(&out_buf, data);
+
         self.wait_busy()?;
 
         trace!("read_regs cmd: {:02x?} data: {:02x?}", out_buf, data);
@@ -251,14 +326,16 @@ where
         &mut self,
         offset: u8,
         data: &[u8],
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>> {
         // Setup register write command
         let out_buf: [u8; 2] = [Commands::WriteBuffer as u8, offset];
 
         trace!("write_buff cmd: {:02x?}", out_buf);
 
         self.wait_busy()?;
-        let r = self.prefix_write(&out_buf, data).map_err(|e| e.into());
+        
+        let r = self.prefix_write(&out_buf, data);
+
         self.wait_busy()?;
         r
     }
@@ -268,15 +345,15 @@ where
         &mut self,
         offset: u8,
         data: &mut [u8],
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), Error<Self::CommsError, Self::PinError, Self::DelayError>> {
         // Setup register read command
         let out_buf: [u8; 3] = [Commands::ReadBuffer as u8, offset, 0];
         trace!(" data: {:02x?}", out_buf);
+
         self.wait_busy()?;
-        let r = self
-            .prefix_read(&out_buf, data)
-            .map(|_| ())
-            .map_err(|e| e.into());
+        
+        let r = self.prefix_read(&out_buf, data);
+
         self.wait_busy()?;
 
         trace!("read_buff cmd: {:02x?} data: {:02x?}", out_buf, data);

--- a/src/device/ble.rs
+++ b/src/device/ble.rs
@@ -5,6 +5,7 @@ use super::common::*;
 /// BLE operating mode channel configuration
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BleChannel {
     /// Operating frequency
     pub freq: u32,
@@ -19,6 +20,7 @@ pub struct BleChannel {
 /// BLE operating mode packet configuration
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BleConfig {
     /// BLE connection state
     pub connection_state: BleConnectionStates,
@@ -32,6 +34,7 @@ pub struct BleConfig {
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum BleConnectionStates {
     // TODO
     BLE_PAYLOAD_LENGTH_MAX_31_BYTES = 0x00,
@@ -46,6 +49,7 @@ pub enum BleConnectionStates {
 /// BLE CRC field configuration
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum BleCrcFields {
     /// CRC disabled
     BLE_CRC_OFF = 0x00,
@@ -56,6 +60,7 @@ pub enum BleCrcFields {
 /// BLE mode packet types
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum BlePacketTypes {
     /// Pseudo Random Binary Sequence based on 9th degree polynomial
     BLE_PRBS_9 = 0x00,

--- a/src/device/common.rs
+++ b/src/device/common.rs
@@ -2,6 +2,7 @@
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "util", derive(structopt::StructOpt))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ModShaping {
     /// No filtering
     Off = 0x00,
@@ -12,6 +13,7 @@ pub enum ModShaping {
 /// Preamble lengths for GFSK, FLRC modes
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PreambleLength {
     /// Preamble length: 04 bits
     PreambleLength04 = 0x00,
@@ -35,6 +37,7 @@ pub enum PreambleLength {
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "util", derive(structopt::StructOpt))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum GfskBleBitrateBandwidth {
     /// Raw baudrate: 2000 kbps Bandwidth: 2.4 MHz
     BR_2_000_BW_2_4 = 0x04,
@@ -67,6 +70,7 @@ pub enum GfskBleBitrateBandwidth {
 /// Modulation Index for GFSK and BLE modes
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum GfskBleModIndex {
     MOD_IND_0_35 = 0,
     MOD_IND_0_50 = 1,
@@ -87,15 +91,17 @@ pub enum GfskBleModIndex {
 }
 
 /// Common radio whitening mode
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug, strum::Display)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum WhiteningModes {
     RADIO_WHITENING_ON = 0x00,
     RADIO_WHITENING_OFF = 0x08,
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug, strum::Display)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SyncWordRxMatch {
     /// No correlator turned on, i.e. do not search for SyncWord
     RADIO_RX_MATCH_SYNCWORD_OFF = 0x00,
@@ -108,8 +114,9 @@ pub enum SyncWordRxMatch {
     RADIO_RX_MATCH_SYNCWORD_1_2_3 = 0x70,
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug, strum::Display)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum GfskFlrcPacketLength {
     /// Fixed length, no header included
     Fixed = 0x00,
@@ -117,8 +124,9 @@ pub enum GfskFlrcPacketLength {
     Variable = 0x20,
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug, strum::Display)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum GfskFlrcCrcModes {
     /// CRC disabled
     RADIO_CRC_OFF = 0x00,

--- a/src/device/flrc.rs
+++ b/src/device/flrc.rs
@@ -5,6 +5,7 @@ use super::common::*;
 /// FLRC configuration structure
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct FlrcChannel {
     /// Operating frequency
     pub freq: u32,
@@ -30,6 +31,7 @@ impl Default for FlrcChannel {
 /// FLRC packet configuration structure
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct FlrcConfig {
     pub preamble_length: PreambleLength,
     pub sync_word_length: FlrcSyncWordLength,
@@ -62,6 +64,7 @@ impl Default for FlrcConfig {
 /// Bit rate / bandwidth pairs for FLRC mode
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum FlrcBitrate {
     /// Baud: 2600 kbps Bandwidth: 2.4 MHz
     BR_2_600_BW_2_4 = 0x04,
@@ -110,6 +113,7 @@ impl std::str::FromStr for FlrcBitrate {
 /// Coding rates for FLRC mode
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum FlrcCodingRate {
     /// 1/2 coding rate
     Cr1_2 = 0x00,
@@ -141,6 +145,7 @@ impl std::str::FromStr for FlrcCodingRate {
 /// FLRC sync word length
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum FlrcSyncWordLength {
     /// No sync word
     None = 0x00,

--- a/src/device/gfsk.rs
+++ b/src/device/gfsk.rs
@@ -5,6 +5,7 @@ use super::common::*;
 /// GFSK operating mode configuration
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct GfskChannel {
     /// Operating frequency
     pub freq: u32,
@@ -30,6 +31,7 @@ impl Default for GfskChannel {
 /// GFSK packet configuration
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct GfskConfig {
     /// Preamble length
     pub preamble_length: PreambleLength,
@@ -69,6 +71,7 @@ impl Default for GfskConfig {
 /// GFSK sync word length configuration
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum GfskSyncWordLength {
     /// Sync word length: 1 byte
     GFSK_SYNCWORD_LENGTH_1_BYTE = 0x00,

--- a/src/device/lora.rs
+++ b/src/device/lora.rs
@@ -3,6 +3,7 @@
 /// LoRa mode radio configuration
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct LoRaConfig {
     // Preamble length in symbols (defaults to 8)
     pub preamble_length: u8,
@@ -31,6 +32,7 @@ impl Default for LoRaConfig {
 /// LoRa mode channel configuration
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct LoRaChannel {
     /// LoRa frequency in Hz (defaults to 2.4GHz)
     pub freq: u32,
@@ -56,6 +58,7 @@ impl Default for LoRaChannel {
 /// Spreading factor for LoRa mode
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum LoRaSpreadingFactor {
     Sf5 = 0x50,
     Sf6 = 0x60,
@@ -70,6 +73,7 @@ pub enum LoRaSpreadingFactor {
 /// Bandwidth for LoRa mode
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum LoRaBandwidth {
     /// 200 kHz bandwidth mode (actually 203.125 kHz)
     Bw200kHz = 0x34,
@@ -96,6 +100,7 @@ impl LoRaBandwidth {
 /// Coding rates for LoRa mode
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum LoRaCodingRate {
     /// LoRa coding rate 4/5
     Cr4_5 = 0x01,
@@ -114,6 +119,7 @@ pub enum LoRaCodingRate {
 /// CRC mode for LoRa packet types
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum LoRaCrc {
     Enabled = 0x20,
     Disabled = 0x00,
@@ -122,6 +128,7 @@ pub enum LoRaCrc {
 /// IQ mode for LoRa packet types
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum LoRaIq {
     Normal = 0x40,
     Inverted = 0x00,
@@ -130,6 +137,7 @@ pub enum LoRaIq {
 /// Header configuration for LoRa packet types
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum LoRaHeader {
     /// Variable length packets, length header included in packet
     Explicit = 0x00,

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -19,6 +19,7 @@ pub const BUSY_TIMEOUT_MS: u32 = 500;
 /// Sx128x general configuration object
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {
     /// Regulator mode configuration
     pub regulator_mode: RegulatorMode,
@@ -123,6 +124,7 @@ impl Config {
 /// Radio modem configuration contains fields for each modem mode
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Modem {
     Gfsk(GfskConfig),
     LoRa(LoRaConfig),
@@ -159,6 +161,7 @@ impl From<&Modem> for PacketType {
 /// Radio channel configuration contains channel options for each mode
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Channel {
     Gfsk(GfskChannel),
     LoRa(LoRaChannel),
@@ -287,6 +290,7 @@ impl core::convert::TryFrom<u8> for CommandStatus {
 /// Power Amplifier configuration
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PaConfig {
     /// Power in dBm
     pub power: i8,
@@ -296,6 +300,7 @@ pub struct PaConfig {
 
 /// Receive packet information
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PacketInfo {
     pub rssi: i16,
     pub rssi_sync: Option<i16>,
@@ -328,6 +333,7 @@ impl Default for PacketInfo {
 /// Regulator operating mode
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum RegulatorMode {
     /// Internal LDO
     Ldo = 0x00,
@@ -338,6 +344,7 @@ pub enum RegulatorMode {
 /// Power amplifier ramp time
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum RampTime {
     /// Ramp over 2us
     Ramp02Us = 0x00,
@@ -360,6 +367,7 @@ pub enum RampTime {
 /// Packet type enumeration
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PacketType {
     Gfsk = 0x00,
     LoRa = 0x01,
@@ -370,8 +378,9 @@ pub enum PacketType {
 }
 
 /// Radio commands
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, strum::Display)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Commands {
     GetStatus = 0xC0,
     WiteRegister = 0x18,
@@ -412,8 +421,9 @@ pub enum Commands {
 }
 
 /// Radio registers
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, strum::Display)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Registers {
     LrFirmwareVersionMsb = 0x0153,
     LrCrcSeedBaseAddr = 0x09C8,
@@ -456,6 +466,7 @@ pub const AUTO_RX_TX_OFFSET: u16 = 33;
 
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AutoTx {
     /// Enable AutoTX with the provided timeout in microseconds (uS)
     Enabled(u16),
@@ -465,6 +476,7 @@ pub enum AutoTx {
 
 bitflags! {
     /// Interrupt flags register
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct Irq: u16 {
         const TX_DONE                             = 0x0001;
         const RX_DONE                             = 0x0002;
@@ -490,6 +502,7 @@ pub type DioMask = Irq;
 
 bitflags! {
     /// Packet status register
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct PacketStatus: u8 {
         /// Top flag value unknown due to lack of complete datasheet
         const UNKNOWN               = (1 << 7);
@@ -505,6 +518,7 @@ bitflags! {
 
 bitflags! {
     /// TxRx status packet status byte
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct TxRxStatus: u8 {
         /// Top flag value unknown due to lack of complete datasheet
         const RX_NO_ACK             = (1 << 5);
@@ -514,6 +528,7 @@ bitflags! {
 
 bitflags! {
     /// TxRx status register
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct SyncAddrStatus: u8 {
         const SYNC_ERROR            = (1 << 6);
     }
@@ -521,6 +536,7 @@ bitflags! {
 
 bitflags! {
     /// Radio calibration parameters
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct CalibrationParams: u8 {
         const ADCBulkPEnable    = (1 << 5);
         const ADCBulkNEnable    = (1 << 4);
@@ -534,6 +550,7 @@ bitflags! {
 /// Ranging mode role
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum RangingRole {
     /// Responder listens for ranging requests and responds
     Responder = 0x00,
@@ -544,6 +561,7 @@ pub enum RangingRole {
 /// TickSize for timeout calculations
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TickSize {
     // 15us tick size
     TickSize0015us = 0x00,
@@ -558,6 +576,7 @@ pub enum TickSize {
 /// Timeout confguration for autonomous radio operations
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Timeout {
     /// Single tx/rx mode
     Single,

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -205,6 +205,7 @@ impl From<&Channel> for PacketType {
 /// Radio state
 #[derive(Clone, Copy, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum State {
     Sleep = 0x00,
     StandbyRc = 0x02,
@@ -251,6 +252,8 @@ impl core::convert::TryFrom<u8> for State {
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+
 pub enum CommandStatus {
     Reserved = 0x0,
     Success = 0x1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,10 @@
 // Copyright 2018 Ryan Kurte
 
 #![no_std]
+#![feature(associated_type_defaults)]
 
 use core::convert::TryFrom;
 use core::fmt::Debug;
-use core::marker::PhantomData;
 
 extern crate libc;
 
@@ -13,6 +13,7 @@ extern crate libc;
 #[macro_use]
 extern crate std;
 
+use base::Base;
 use log::{debug, error, trace, warn};
 
 use embedded_hal::delay::blocking::DelayUs;
@@ -20,7 +21,6 @@ use embedded_hal::digital::blocking::{InputPin, OutputPin};
 use embedded_hal::spi::blocking::{Transactional, Transfer, Write};
 use embedded_hal::spi::{Mode as SpiMode, Phase, Polarity};
 
-use driver_pal::{wrapper::Wrapper as SpiWrapper, Error as WrapError};
 
 pub use radio::{Channel as _, Interrupts as _, State as _};
 
@@ -39,14 +39,10 @@ pub const SPI_MODE: SpiMode = SpiMode {
 };
 
 /// Sx128x device object
-pub struct Sx128x<Base, CommsError, PinError, DelayError> {
+pub struct Sx128x<Base> {
     config: Config,
     packet_type: PacketType,
     hal: Base,
-
-    _ce: PhantomData<CommsError>,
-    _pe: PhantomData<PinError>,
-    _de: PhantomData<DelayError>,
 }
 
 pub const FREQ_MIN: u32 = 2_400_000_000;
@@ -147,50 +143,33 @@ pub enum Error<CommsError: Debug + 'static, PinError: Debug + 'static, DelayErro
     NoComms,
 }
 
-impl<CommsError, PinError, DelayError> From<WrapError<CommsError, PinError, DelayError>>
-    for Error<CommsError, PinError, DelayError>
-where
-    CommsError: Debug + 'static,
-    PinError: Debug + 'static,
-    DelayError: Debug + 'static,
-{
-    fn from(e: WrapError<CommsError, PinError, DelayError>) -> Self {
-        match e {
-            WrapError::Spi(e) => Error::Comms(e),
-            WrapError::Pin(e) => Error::Pin(e),
-            WrapError::Delay(e) => Error::Delay(e),
-            WrapError::Aborted => Error::Aborted,
-        }
-    }
+pub type Sx128xSpi<Spi, CsPin, BusyPin, ReadyPin, SdnPin, DelayPin> = Sx128x<Base<Spi, CsPin, BusyPin, ReadyPin, SdnPin, DelayPin>>;
+
+/// Helper to group SPI functions by error, not needed when e-h@1.0.0-alpha.8 lands
+pub trait SpiBase: Transfer<u8, Error = <Self as SpiBase>::Error> + Write<u8, Error = <Self as SpiBase>::Error> + Transactional<u8, Error = <Self as SpiBase>::Error> {
+    type Error;
 }
 
-pub type Sx128xSpi<Spi, SpiError, CsPin, BusyPin, ReadyPin, SdnPin, PinError, Delay, DelayError> =
-    Sx128x<
-        SpiWrapper<Spi, CsPin, BusyPin, ReadyPin, SdnPin, Delay>,
-        SpiError,
-        PinError,
-        DelayError,
-    >;
+impl <T: Transfer<u8, Error = E> + Write<u8, Error = E> + Transactional<u8, Error = E>, E> SpiBase for T {
+    type Error = E;
+}
 
-impl<Spi, CommsError, CsPin, BusyPin, ReadyPin, SdnPin, PinError, Delay, DelayError>
+impl<Spi, CsPin, BusyPin, ReadyPin, SdnPin, PinError, Delay>
     Sx128x<
-        SpiWrapper<Spi, CsPin, BusyPin, ReadyPin, SdnPin, Delay>,
-        CommsError,
-        PinError,
-        DelayError,
+        Base<Spi, CsPin, BusyPin, ReadyPin, SdnPin, Delay>,
     >
 where
-    Spi: Transfer<u8, Error = CommsError>
-        + Write<u8, Error = CommsError>
-        + Transactional<u8, Error = CommsError>,
+    Spi: SpiBase,
+    <Spi as SpiBase>::Error: Debug,
+
     CsPin: OutputPin<Error = PinError>,
     BusyPin: InputPin<Error = PinError>,
     ReadyPin: InputPin<Error = PinError>,
     SdnPin: OutputPin<Error = PinError>,
-    Delay: DelayUs<Error = DelayError>,
-    CommsError: Debug + 'static,
-    PinError: Debug + 'static,
-    DelayError: Debug + 'static,
+    PinError: Debug,
+
+    Delay: DelayUs,
+    <Delay as DelayUs>::Error: Debug,
 {
     /// Create an Sx128x with the provided `Spi` implementation and pins
     pub fn spi(
@@ -198,26 +177,26 @@ where
         cs: CsPin,
         busy: BusyPin,
         ready: ReadyPin,
-        reset: SdnPin,
+        sdn: SdnPin,
         delay: Delay,
         config: &Config,
-    ) -> Result<Self, Error<CommsError, PinError, DelayError>> {
+    ) -> Result<Self, Error<<Spi as SpiBase>::Error, PinError, <Delay as DelayUs>::Error>> {
         // Create SpiWrapper over spi/cs/busy
-        let hal = SpiWrapper::new(spi, cs, reset, busy, ready, delay);
+        let hal = Base{spi, cs, sdn, busy, ready, delay};
         // Create instance with new hal
         Self::new(hal, config)
     }
 }
 
-impl<Hal, CommsError, PinError, DelayError> Sx128x<Hal, CommsError, PinError, DelayError>
+impl<Hal> Sx128x<Hal>
 where
-    Hal: base::Hal<CommsError, PinError, DelayError>,
-    CommsError: Debug + 'static,
-    PinError: Debug + 'static,
-    DelayError: Debug + 'static,
+    Hal: base::Hal,
+    <Hal as base::Hal>::CommsError: Debug + 'static,
+    <Hal as base::Hal>::PinError: Debug + 'static,
+    <Hal as base::Hal>::DelayError: Debug + 'static,
 {
     /// Create a new Sx128x instance over a generic Hal implementation
-    pub fn new(hal: Hal, config: &Config) -> Result<Self, Error<CommsError, PinError, DelayError>> {
+    pub fn new(hal: Hal, config: &Config) -> Result<Self, Error<<Hal as base::Hal>::CommsError, <Hal as base::Hal>::PinError, <Hal as base::Hal>::DelayError>> {
         let mut sx128x = Self::build(hal);
 
         debug!("Resetting device");
@@ -258,7 +237,7 @@ where
         Ok(sx128x)
     }
 
-    pub fn reset(&mut self) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    pub fn reset(&mut self) -> Result<(), <Hal as base::HalError>::E> {
         debug!("Resetting device");
 
         self.hal.reset()?;
@@ -271,16 +250,13 @@ where
             config: Config::default(),
             packet_type: PacketType::None,
             hal,
-            _ce: PhantomData,
-            _pe: PhantomData,
-            _de: PhantomData,
         }
     }
 
     pub fn configure(
         &mut self,
         config: &Config,
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), <Hal as base::HalError>::E> {
         // Switch to standby mode
         self.set_state(State::StandbyRc)?;
 
@@ -310,7 +286,7 @@ where
         Ok(())
     }
 
-    pub fn firmware_version(&mut self) -> Result<u16, Error<CommsError, PinError, DelayError>> {
+    pub fn firmware_version(&mut self) -> Result<u16, <Hal as base::HalError>::E> {
         let mut d = [0u8; 2];
 
         self.hal
@@ -319,7 +295,7 @@ where
         Ok((d[0] as u16) << 8 | (d[1] as u16))
     }
 
-    pub fn set_frequency(&mut self, f: u32) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    pub fn set_frequency(&mut self, f: u32) -> Result<(), <Hal as base::HalError>::E> {
         let c = self.config.freq_to_steps(f as f32) as u32;
 
         trace!("Setting frequency ({:?} MHz, {} index)", f / 1000 / 1000, c);
@@ -333,7 +309,7 @@ where
         &mut self,
         power: i8,
         ramp: RampTime,
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), <Hal as base::HalError>::E> {
         if power > 13 || power < -18 {
             warn!("TX power out of range (-18 < p < 13)");
         }
@@ -361,7 +337,7 @@ where
     pub fn set_irq_mask(
         &mut self,
         irq: Irq,
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), <Hal as base::HalError>::E> {
         trace!("Setting IRQ mask: {:?}", irq);
 
         let raw = irq.bits();
@@ -378,7 +354,7 @@ where
         dio1: DioMask,
         dio2: DioMask,
         dio3: DioMask,
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), <Hal as base::HalError>::E> {
         trace!(
             "Setting IRQ mask: {:?} DIOs: {:?}, {:?}, {:?}",
             irq,
@@ -409,7 +385,7 @@ where
     pub(crate) fn configure_modem(
         &mut self,
         config: &Modem,
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), <Hal as base::HalError>::E> {
         use Modem::*;
 
         debug!("Setting modem config: {:?}", config);
@@ -486,7 +462,7 @@ where
 
     pub(crate) fn get_rx_buffer_status(
         &mut self,
-    ) -> Result<(u8, u8), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(u8, u8), <Hal as base::HalError>::E> {
         use device::lora::LoRaHeader;
 
         let mut status = [0u8; 2];
@@ -514,7 +490,7 @@ where
     pub(crate) fn get_packet_info(
         &mut self,
         info: &mut PacketInfo,
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), <Hal as base::HalError>::E> {
         let mut data = [0u8; 5];
         self.hal
             .read_cmd(Commands::GetPacketStatus as u8, &mut data)?;
@@ -548,7 +524,7 @@ where
     pub fn calibrate(
         &mut self,
         c: CalibrationParams,
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), <Hal as base::HalError>::E> {
         trace!("Calibrate {:?}", c);
         self.hal.write_cmd(Commands::Calibrate as u8, &[c.bits()])
     }
@@ -556,7 +532,7 @@ where
     pub(crate) fn set_regulator_mode(
         &mut self,
         r: RegulatorMode,
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), <Hal as base::HalError>::E> {
         trace!("Set regulator mode {:?}", r);
         self.hal
             .write_cmd(Commands::SetRegulatorMode as u8, &[r as u8])
@@ -567,7 +543,7 @@ where
     pub(crate) fn set_auto_tx(
         &mut self,
         a: AutoTx,
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), <Hal as base::HalError>::E> {
         let data = match a {
             AutoTx::Enabled(timeout_us) => {
                 let compensated = timeout_us - AUTO_RX_TX_OFFSET;
@@ -582,7 +558,7 @@ where
         &mut self,
         tx: u8,
         rx: u8,
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), <Hal as base::HalError>::E> {
         trace!("Set buff base address (tx: {}, rx: {})", tx, rx);
         self.hal
             .write_cmd(Commands::SetBufferBaseAddress as u8, &[tx, rx])
@@ -594,7 +570,7 @@ where
         &mut self,
         index: u8,
         value: &[u8],
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), <Hal as base::HalError>::E> {
         trace!(
             "Attempting to set sync word index: {} to: {:?}",
             index,
@@ -648,7 +624,7 @@ where
     }
 
     /// Apply patch for sync-word match errata in FLRC mode
-    fn patch_flrc_syncword(&mut self) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    fn patch_flrc_syncword(&mut self) -> Result<(), <Hal as base::HalError>::E> {
         // If we're in FLRC mode, patch to force 100% match on syncwords
         // because otherwise the 4 bit threshold is too low
         if let PacketType::Flrc = &self.packet_type {
@@ -661,15 +637,11 @@ where
     }
 }
 
-impl<Hal, CommsError, PinError, DelayError> DelayUs
-    for Sx128x<Hal, CommsError, PinError, DelayError>
+impl<Hal> DelayUs for Sx128x<Hal>
 where
-    Hal: base::Hal<CommsError, PinError, DelayError>,
-    CommsError: Debug + 'static,
-    PinError: Debug + 'static,
-    DelayError: Debug + 'static,
+    Hal: base::Hal,
 {
-    type Error = Error<CommsError, PinError, DelayError>;
+    type Error = <Hal as base::HalError>::E;
 
     fn delay_us(&mut self, t: u32) -> Result<(), Self::Error> {
         self.hal.delay_us(t).map_err(|e| Error::Delay(e))
@@ -677,16 +649,13 @@ where
 }
 
 /// `radio::State` implementation for the SX128x
-impl<Hal, CommsError, PinError, DelayError> radio::State
-    for Sx128x<Hal, CommsError, PinError, DelayError>
+impl<Hal> radio::State
+    for Sx128x<Hal>
 where
-    Hal: base::Hal<CommsError, PinError, DelayError>,
-    CommsError: Debug + 'static,
-    PinError: Debug + 'static,
-    DelayError: Debug + 'static,
+    Hal: base::Hal,
 {
     type State = State;
-    type Error = Error<CommsError, PinError, DelayError>;
+    type Error = <Hal as base::HalError>::E;
 
     /// Fetch device state
     fn get_state(&mut self) -> Result<Self::State, Self::Error> {
@@ -726,15 +695,12 @@ where
 }
 
 /// `radio::Busy` implementation for the SX128x
-impl<Hal, CommsError, PinError, DelayError> radio::Busy
-    for Sx128x<Hal, CommsError, PinError, DelayError>
+impl<Hal> radio::Busy
+    for Sx128x<Hal>
 where
-    Hal: base::Hal<CommsError, PinError, DelayError>,
-    CommsError: Debug + 'static,
-    PinError: Debug + 'static,
-    DelayError: Debug + 'static,
+    Hal: base::Hal,
 {
-    type Error = Error<CommsError, PinError, DelayError>;
+    type Error = <Hal as base::HalError>::E;
 
     /// Fetch device state
     fn is_busy(&mut self) -> Result<bool, Self::Error> {
@@ -751,18 +717,15 @@ where
 }
 
 /// `radio::Channel` implementation for the SX128x
-impl<Hal, CommsError, PinError, DelayError> radio::Channel
-    for Sx128x<Hal, CommsError, PinError, DelayError>
+impl<Hal> radio::Channel
+    for Sx128x<Hal>
 where
-    Hal: base::Hal<CommsError, PinError, DelayError>,
-    CommsError: Debug + 'static,
-    PinError: Debug + 'static,
-    DelayError: Debug + 'static,
+    Hal: base::Hal,
 {
     /// Channel consists of an operating frequency and packet mode
     type Channel = Channel;
 
-    type Error = Error<CommsError, PinError, DelayError>;
+    type Error = <Hal as base::HalError>::E;
 
     /// Set operating channel
     fn set_channel(&mut self, ch: &Self::Channel) -> Result<(), Self::Error> {
@@ -800,34 +763,28 @@ where
 }
 
 /// `radio::Power` implementation for the SX128x
-impl<Hal, CommsError, PinError, DelayError> radio::Power
-    for Sx128x<Hal, CommsError, PinError, DelayError>
+impl<Hal> radio::Power
+    for Sx128x<Hal>
 where
-    Hal: base::Hal<CommsError, PinError, DelayError>,
-    CommsError: Debug + 'static,
-    PinError: Debug + 'static,
-    DelayError: Debug + 'static,
+    Hal: base::Hal,
 {
-    type Error = Error<CommsError, PinError, DelayError>;
+    type Error = <Hal as base::HalError>::E;
 
     /// Set TX power in dBm
-    fn set_power(&mut self, power: i8) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    fn set_power(&mut self, power: i8) -> Result<(), <Hal as base::HalError>::E> {
         let ramp_time = self.config.pa_config.ramp_time;
         self.set_power_ramp(power, ramp_time)
     }
 }
 
 /// `radio::Interrupts` implementation for the SX128x
-impl<Hal, CommsError, PinError, DelayError> radio::Interrupts
-    for Sx128x<Hal, CommsError, PinError, DelayError>
+impl<Hal> radio::Interrupts
+    for Sx128x<Hal>
 where
-    Hal: base::Hal<CommsError, PinError, DelayError>,
-    CommsError: Debug + 'static,
-    PinError: Debug + 'static,
-    DelayError: Debug + 'static,
+    Hal: base::Hal,
 {
     type Irq = Irq;
-    type Error = Error<CommsError, PinError, DelayError>;
+    type Error = <Hal as base::HalError>::E;
 
     /// Fetch (and optionally clear) current interrupts
     fn get_interrupts(&mut self, clear: bool) -> Result<Self::Irq, Self::Error> {
@@ -849,15 +806,12 @@ where
 }
 
 /// `radio::Transmit` implementation for the SX128x
-impl<Hal, CommsError, PinError, DelayError> radio::Transmit
-    for Sx128x<Hal, CommsError, PinError, DelayError>
+impl<Hal> radio::Transmit
+    for Sx128x<Hal>
 where
-    Hal: base::Hal<CommsError, PinError, DelayError>,
-    CommsError: Debug + 'static,
-    PinError: Debug + 'static,
-    DelayError: Debug + 'static,
+    Hal: base::Hal,
 {
-    type Error = Error<CommsError, PinError, DelayError>;
+    type Error = <Hal as base::HalError>::E;
 
     /// Start transmitting a packet
     fn start_transmit(&mut self, data: &[u8]) -> Result<(), Self::Error> {
@@ -949,19 +903,16 @@ where
 }
 
 /// `radio::Receive` implementation for the SX128x
-impl<Hal, CommsError, PinError, DelayError> radio::Receive
-    for Sx128x<Hal, CommsError, PinError, DelayError>
+impl<Hal> radio::Receive
+    for Sx128x<Hal>
 where
-    Hal: base::Hal<CommsError, PinError, DelayError>,
-    CommsError: Debug + 'static,
-    PinError: Debug + 'static,
-    DelayError: Debug + 'static,
+    Hal: base::Hal,
 {
     /// Receive info structure
     type Info = PacketInfo;
 
     /// RF Error object
-    type Error = Error<CommsError, PinError, DelayError>;
+    type Error = <Hal as base::HalError>::E;
 
     /// Start radio in receive mode
     fn start_receive(&mut self) -> Result<(), Self::Error> {
@@ -1102,19 +1053,16 @@ where
 }
 
 /// `radio::Rssi` implementation for the SX128x
-impl<Hal, CommsError, PinError, DelayError> radio::Rssi
-    for Sx128x<Hal, CommsError, PinError, DelayError>
+impl<Hal> radio::Rssi
+    for Sx128x<Hal>
 where
-    Hal: base::Hal<CommsError, PinError, DelayError>,
-    CommsError: Debug + 'static,
-    PinError: Debug + 'static,
-    DelayError: Debug + 'static,
+    Hal: base::Hal,
 {
-    type Error = Error<CommsError, PinError, DelayError>;
+    type Error = <Hal as base::HalError>::E;
 
     /// Poll for the current channel RSSI
     /// This should only be called when in receive mode
-    fn poll_rssi(&mut self) -> Result<i16, Error<CommsError, PinError, DelayError>> {
+    fn poll_rssi(&mut self) -> Result<i16, <Hal as base::HalError>::E> {
         let mut raw = [0u8; 1];
         self.hal.read_cmd(Commands::GetRssiInst as u8, &mut raw)?;
         Ok(-(raw[0] as i16) / 2)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub const NUM_RETRIES: usize = 3;
 /// Sx128x error type
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error<CommsError: Debug + 'static, PinError: Debug + 'static, DelayError: Debug + 'static>
 {
     #[cfg_attr(feature = "thiserror", error("communication error: {:?}", 0))]


### PR DESCRIPTION
cleans up trait bounds so they are _hopefully_ more clear which should improve further with `e-h@1.0.0-alpha.8`. also made `driver-pal` optional / only required for util.

cc. @henrikssn 